### PR TITLE
Fix UpdateValueCtrl date typo

### DIFF
--- a/app/scripts/controllers/dialogs/UpdateValueCtrl.js
+++ b/app/scripts/controllers/dialogs/UpdateValueCtrl.js
@@ -18,7 +18,7 @@ angular.module('charttab').controller('UpdateValueCtrl', function (
 
     vm.minDate = moment(vm.chartData.start, config.dateFormat).startOf('isoWeek').subtract(1, 'days').toDate();
 
-    vm.maxDate = moment(vm.chartData.end, config.dateFormat).endOf('isonWeek').toDate();
+    vm.maxDate = moment(vm.chartData.end, config.dateFormat).endOf('isoWeek').toDate();
 
     vm.update = function () {
         krs.updateValue(vm.chartData.id, vm.data.date, vm.data.value).then(ui.hideDialog);


### PR DESCRIPTION
## Summary
- fix typo in UpdateValueCtrl when calculating max date

## Testing
- `npm test` *(fails: eslint not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840556c5a80832396a9d0253ec3352e