### PR TITLE
Fix hideDialog call in settings form

### DIFF
--- a/app/scripts/controllers/dialogs/SettingsFormCtrl.js
+++ b/app/scripts/controllers/dialogs/SettingsFormCtrl.js
@@ -29,7 +29,7 @@ angular.module('charttab').controller('SettingsFormCtrl', function (
         let config = angular.copy(vm.config);
         SettingsService.updateConfig(config).then(() => {
             chrome.tabs.reload();
-            ui.hideDialog;
+            ui.hideDialog();
         });
     };
 


### PR DESCRIPTION
## Summary
- fix call to hideDialog in settings controller

## Testing
- `npm test` *(fails: `./node_modules/.bin/eslint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68405718409883238185c92bd06e7c6b