### PR TITLE
Add JSDoc for uid service

### DIFF
--- a/app/scripts/services/uid.js
+++ b/app/scripts/services/uid.js
@@ -1,3 +1,7 @@
+/**
+ * Service that returns a function generating a pseudo-random string
+ * identifier.
+ */
 angular.module('charttab').factory('uid', function () {
 
     function uid() {


### PR DESCRIPTION
## Summary
- document uid service

## Testing
- `npm test` *(fails: `./node_modules/.bin/eslint: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6840572588248323a6c99c9f1f1b0589